### PR TITLE
Add Views WebServices to enable list of fields in View::view_fields

### DIFF
--- a/lib/viewpoint/spws/spws_client.rb
+++ b/lib/viewpoint/spws/spws_client.rb
@@ -39,6 +39,11 @@ class Viewpoint::SPWSClient
     @listsws ||= Websvc::Lists.new(@con)
   end
 
+  def views_ws
+    @views ||= Websvc::Views.new(@con)
+  end
+
+
   def usergroup_ws
     @usergroupws ||= Websvc::UserGroup.new(@con)
   end
@@ -67,6 +72,11 @@ class Viewpoint::SPWSClient
   # Retrieve all of the viewable lists for this site.
   def get_lists
     lists_ws.get_list_collection
+  end
+
+  # Retrieve all of the viewable list_items for the list.
+  def get_list_items(list, opts = {})
+    lists_ws.get_list_items(list, opts)
   end
 
   # Retrieve a List object
@@ -104,4 +114,14 @@ class Viewpoint::SPWSClient
     end
     usergroup_ws.get_user_info user
   end
+
+  # ========= Views Accessor Proxy Methods =========
+  def get_view_collection(list_name)
+      views_ws.get_view_collection(list_name)
+  end
+
+  def get_view(list_name, view_name)
+      views_ws.get_view(list_name, view_name)
+  end
+
 end

--- a/lib/viewpoint/spws/types/list_item.rb
+++ b/lib/viewpoint/spws/types/list_item.rb
@@ -24,6 +24,7 @@ class Viewpoint::SPWS::Types::ListItem
   attr_reader :id, :body, :file_name, :file_ref, :editor, :guid, :object_type
   attr_reader :created_date, :modified_date, :due_date
   attr_reader :title, :link_title, :status, :priority, :percent_complete
+  attr_reader :fields
 
   # @param [Viewpoint::SPWS::Websvc::List] ws The webservice instance this ListItem spawned from
   # @param [String] list_id The list id that this item belongs to
@@ -215,6 +216,13 @@ class Viewpoint::SPWS::Types::ListItem
     set_field   :@modified_date, 'ows_Modified'
     set_field   :@created_date, 'ows_Created_x0020_Date' unless @created_date
     set_field   :@modified_date, 'ows_Last_x0020_Modified' unless @modified_date
+    begin
+        @fields = {}
+        xml.attributes.each do |a|
+          (@fields[a[1].name.gsub(/^ows_/, '')] = a[1].value rescue true)
+        end
+    rescue true
+    end
     @xmldoc = nil
   end
 

--- a/lib/viewpoint/spws/types/view.rb
+++ b/lib/viewpoint/spws/types/view.rb
@@ -1,0 +1,28 @@
+class Viewpoint::SPWS::Types::View
+  include Viewpoint::SPWS::Types
+
+  attr_reader :name, :default_view, :mobile_view, :mobile_default_view, :type
+  attr_reader :display_name, :url, :level, :base_viewID, :content_typeID, :imageUrl
+  attr_reader :view_fields
+
+  def initialize(ws, xml)
+    @ws = ws
+    @view_fields = nil
+    parse_xml_fields(xml)
+    ns = {"xmlns" => xml.namespace.href}
+    xml.xpath('//xmlns:ViewFields/xmlns:FieldRef', ns).each do |l|
+        @view_fields ||= []
+        @view_fields << l.attributes['Name'].value
+    end
+  end
+
+  def parse_xml_fields(xml)
+    [:name, :default_view, :mobile_view, :mobile_default_view, :type,
+     :display_name, :url, :level, :base_viewID, :content_typeID, :imageUrl].each do |a|
+	# var = "@#{a}".to_sym
+        # val = xml[a.to_s.camel_case]
+	# puts "#{var.inspect} -> #{val.inspect}"
+	instance_variable_set   "@#{a}".to_sym, xml[a.to_s.camel_case]
+    end
+  end
+end

--- a/lib/viewpoint/spws/websvc/lists.rb
+++ b/lib/viewpoint/spws/websvc/lists.rb
@@ -216,7 +216,7 @@ class Viewpoint::SPWS::Websvc::Lists
               builder.ViewFields {
                 builder.parent.default_namespace = ''
                 opts[:view_fields].each do |f|
-                  builder.FieldRef(:Name => f.to_s.camel_case)
+                  builder.FieldRef(:Name => f.to_s) # .camel_case)
                 end
               }
             }

--- a/lib/viewpoint/spws/websvc/views.rb
+++ b/lib/viewpoint/spws/websvc/views.rb
@@ -1,0 +1,65 @@
+=begin
+  This file is part of ViewpointSPWS; the Ruby library for Microsoft Sharepoint Web Services.
+
+  Copyright © 2011 Dan Wanek <dan.wanek@gmail.com>
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+=end
+
+# This class represents the Sharepoint Lists Web Service.
+# @see http://msdn.microsoft.com/en-us/library/ms774654(v=office.12).aspx
+class Viewpoint::SPWS::Websvc::Views
+  include Viewpoint::SPWS::Websvc::WebServiceBase
+
+  def initialize(spcon)
+    @default_ns  = 'http://schemas.microsoft.com/sharepoint/soap/'
+    @ws_endpoint = '_vti_bin/Views.asmx'
+    super
+  end
+
+  def get_view_collection(listName)
+    soapmsg = build_soap_envelope do |type, builder|
+      if(type == :header)
+      else
+        builder.GetViewCollection {
+          builder.parent.default_namespace = @default_ns
+          builder.listName(listName)
+        }
+      end
+    end
+    soaprsp = Nokogiri::XML(send_soap_request(soapmsg.doc.to_xml))
+    ns = {"xmlns"=> @default_ns}
+    views = []
+    soaprsp.xpath('//xmlns:GetViewCollectionResponse/xmlns:GetViewCollectionResult/xmlns:Views/xmlns:View', ns).each do |l|
+      views << Types::View.new(self, l)
+    end
+    views
+  end
+
+  def get_view(listName, viewName)
+    soapmsg = build_soap_envelope do |type, builder|
+      if(type == :header)
+      else
+        builder.GetView {
+          builder.parent.default_namespace = @default_ns
+          builder.listName(listName)
+          builder.viewName(viewName)
+        }
+      end
+    end
+    soaprsp = Nokogiri::XML(send_soap_request(soapmsg.doc.to_xml))
+    ns = {"xmlns"=> @default_ns}
+    Types::View.new(self, soaprsp.xpath('//xmlns:GetViewResponse/xmlns:GetViewResult/xmlns:View', ns).first)
+  end
+
+end


### PR DESCRIPTION
I'd like to read list_items from SharePonit with custom fields:
1) there is need to read list of fields from View
   a) so we need to get View::name
   b) a than to get View::view_fields
2) use view_fields !!! don't change name by camel_case notation !!! to read the values in list_items

see my example:
 require 'rubygems'
 require 'viewpoint/spws'
 site = 'http://example.site.com/ProjectZone/default.aspx'
 user = 'DOMAIN\user'
 pass = 'UserPassword'
 # If using GSSAPI and the 'gssapi' gem you do not need to specify a user/pass
 scli = Viewpoint::SPWSClient.new(site)
 # Otherwise you can specify a user/pass
 scli = Viewpoint::SPWSClient.new(site, user, pass)

 require 'pp'
 list_name = 'ListOfProjects'
 view_name = scli.get_view_collection(list_name).first.name
 view = scli.get_view(list_name, view_name)
 i = scli.get_list_items('ListOfProjects', :view_name => view_name, :view_fields => view.view_fields).first
 pp i.fields
